### PR TITLE
Also build for linux/arm64

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,7 +2,7 @@ name: Deploy image to GHCR 🪂
 
 env:
   REGISTRY: ghcr.io
-  PLATFORMS: linux/amd64
+  PLATFORMS: linux/amd64,linux/arm64
 
 on:
   repository_dispatch:


### PR DESCRIPTION
Given that these images are small, we should be able to build arm64 images.